### PR TITLE
HTTP headers and API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Yak is an ORM that maps RESTful resources to JavaScript models/collections.
 Inspired by [Backbone.js](http://backbonejs.org/) and [Her](http://www.her-rb.org/), Yak is designed to build applications that are powered by a RESTful JSON API instead of a database. Yak uses `window.fetch` on the client, and
 `node-fetch` on the server, which makes it really easy for you to write a persistence layer in an isomorphic fashion.
 
+## Installation & Requirements
+
+Yak requires Node.js >= 4.0. To run in a web browser environment you'll need native or polyfilled support for
+ES6 Promises, Object.assign, Fat Arrow Syntax, and the window.fetch API.
+
+Run `npm install yak-orm` and then require it in your project:
+
+```js
+var Yak = require('yak-orm');
+var yak = new Yak({
+  host: "http://localhost:8080/"
+});
+```
+
+You should now be ready to go!
+
+
 ## Yak is a work in progress
 
 Features that are on the roadmap but *not yet* currently implemented include:
@@ -24,7 +41,7 @@ Features that are on the roadmap but *not yet* currently implemented include:
 Create a new Yak instance
 
 #### Arguments
-host (String) | Specify your API endpoint here
+- host (String) | Specify your API endpoint here
 
 #### Example
 ```js
@@ -34,34 +51,17 @@ var yak = new Yak({
 });
 ```
 
-### yakInstance.setHeaders
-
-Change the HTTP headers that are being sent when a request is made in Yak.
-
-#### Arguments
-headers (Object) | Any HTTP headers that you can think of!
-
-#### Example
-```js
-// On the fly HTTP header configration
-yak.setHeaders({
-  'Accept-Language' : 'en',
-  'Authentication-Token': 'abc123'
-});
-```
-
-
-### yakInstance.Model
+### yakInstance.model
 
 Create a new model based on a Yak instance
 
 #### Arguments
-url (String) | The URL of specified model on API server
+- url (String) | The URL of specified model on API server
 
 #### Example
 ```js
 // Model defintion
-var User = yak.Model({
+var User = yak.model({
   url: "users"
 });
 ```
@@ -71,14 +71,21 @@ var User = yak.Model({
 Create a new instance of a model
 
 #### Arguments
-attrs (Object) | An object of attributes that will be asigned to the model
+- attrs (Object) | An object of attributes that will be assigned to the model
+- headers (Object) | Specify HTTP headers to be sent along with any model requests
 
 #### Example
 ```js
 // Create a new user
 var user = new User({
-  name: "John",
-  email: "john@doe.com"
+  attrs: {
+    name: "John",
+    email: "john@doe.com"
+  },
+  headers: {
+    'Accept-Language' : 'en',
+    'Authentication-Token': 'abc123'
+  }
 });
 ```
 
@@ -87,12 +94,22 @@ var user = new User({
 Retrieve a model from server
 
 #### Arguments
-id (String) | An identifer that will be used to fetch the resource
+- id (String) | An identifier that will be used to fetch the resource
+- where (Object) | Additional query parameters to be sent in request
+- headers (Object) | Specify HTTP headers to be sent along with the request
 
 #### Example
 ```js
-// GET http://localhost:8080/users/1
-var user = User.get(1).then(user => {
+// GET http://localhost:8080/users/1?active=true
+var user = User.get({
+  id: 5,
+  where: {
+    active: true
+  }
+  headers: {
+    'Accept-Language' : 'fa',
+  }
+}).then(user => {
   console.log("Retrieved user:", user.attrs);
 }).catch(error => {
   console.log(error);
@@ -102,6 +119,10 @@ var user = User.get(1).then(user => {
 ### Model.all
 
 Retrieve a collection of models from server
+
+#### Arguments
+- where (Object) | Additional query parameters to be sent in request
+- headers (Object) | Specify HTTP headers to be sent along with the request
 
 #### Example
 ```js

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -5,19 +5,13 @@ var yak = new Yak({
   host: "http://localhost:8080/"
 })
 
-// On the fly HTTP header configration
-yak.setHeaders({
-  'Accept-Language' : 'en',
-  'Authentication-Token': 'abc123'
-});
-
 // Model defintion
-var User = yak.Model({
+var User = yak.model({
   url: "users"
 });
 
 // Get existing user
-var user = User.get(1).then(user => {
+var user = User.get({id: 1}).then(user => {
   console.log("Retrieved user:", user.attrs);
 }).catch(error => {
   console.log(error);
@@ -25,8 +19,10 @@ var user = User.get(1).then(user => {
 
 // Create a new user
 var user = new User({
-  name: "Daniel",
-  email: "daniel@webcloud.se"
+  attrs: {
+    name: "Daniel",
+    email: "daniel@webcloud.se"
+  }
 });
 
 // Persist to server
@@ -39,12 +35,16 @@ user.save().then(user => {
 });
 
 // Get all users
-User.all().then(users => {
-  users.models.forEach(user => {
+User.all({
+    where: {
+      active : true
+    }
+  }).then(users => {
+  users.forEach(user => {
     console.log(user.attrs.id, user.attrs.name);
   });
   // Delete the first user
-  return users.models[0].destroy();
+  return users[0].destroy();
 }).then(user => {
   console.log("Deleted user:", user.attrs.id);
 });

--- a/index.js
+++ b/index.js
@@ -1,15 +1,9 @@
-var Model = require('./lib/model');
+var model = require('./lib/model');
 
 module.exports = function(options) {
-
-  Model.yak = this;
-  this.Model = Model;
+  this.model = model;
   this.headers = {
     'Content-Type': 'application/json'
   }
   this.host = options.host;
-
-  this.setHeaders = function(options) {
-    Object.assign(this.headers, options);
-  }
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,8 +1,8 @@
 var _ = require('lodash');
 var fetch = require('node-fetch');
+var toQueryString = require('querystring').stringify;
 
-function Model(obj) {
-  var headers = this.headers;
+function model(obj) {
   var host = this.host;
   var endpoint = host + obj.url;
 
@@ -10,11 +10,18 @@ function Model(obj) {
    * Wraps fetch method, returns a Promise.
    */
   var request = function(method, endpoint, cb) {
+    var headers = this.headers;
+    var body = ['POST', 'PUT', 'PATCH'].indexOf(method) > -1 ? JSON.stringify(this.attrs) : null;
+    // Temporary work around until https://github.com/bitinn/node-fetch/issues/47
+    // is resolved
+    if(body) {
+      headers['content-length'] == Buffer.byteLength(body);
+    }
     return new Promise((resolve, reject) => {
       fetch(endpoint, {
         method: method,
         headers: headers,
-        body: (method == "POST" || method == "PATCH") ? JSON.stringify(this.attrs) : null
+        body: body
       }).then(res => {
         return res.json();
       }).then(json => {
@@ -25,13 +32,12 @@ function Model(obj) {
     });
   }
 
-  var fn = function(attrs) {
+  var fn = function(obj) {
     _.extend(this, {
-      errors : {},
-      headers: headers,
       host: host,
-      attrs: _.cloneDeep(attrs),
+      attrs: _.cloneDeep(obj.attrs) || {},
       url: obj.url,
+      headers: obj.headers || {},
       endpoint: endpoint,
       request: request,
     });
@@ -43,16 +49,15 @@ function Model(obj) {
   /*
    * GET /resource
    * -------------
-   * Returns a collection of models of specified resource
+   * Returns an Array of models of specified resource
    */
-  fn.all = function() {
-    return request('GET', endpoint, {
+  fn.all = function(obj) {
+    var qs = 'where' in obj ? '?' + toQueryString(obj.where) : '';
+    return request('GET', endpoint + qs, {
       success: function(json) {
-        var collection = {};
-        collection.models = json.map(item => {
-          return new fn(item);
+        return json.map(attrs => {
+          return new fn({ attrs: attrs });
         });
-        return collection;
       },
       error: function(error) {
         return error;
@@ -65,10 +70,11 @@ function Model(obj) {
    * -------------
    * Returns a single models of specified resource
    */
-  fn.get = function(id) {
-    return request('GET', endpoint + '/' + id, {
+  fn.get = function(obj) {
+    var qs = 'where' in obj ? '?' + toQueryString(obj.where) : '';
+    return request('GET', endpoint + '/' + obj.id + qs, {
       success: function(json) {
-        return new fn(json);
+        return new fn({ attrs: json });
       },
       error: function(error) {
         return error;
@@ -125,7 +131,7 @@ var methods = {
    * Updates resource of specified model
    */
   destroy: function() {
-    return this.request('GET', this.endpoint + '/' + this.attrs.id, {
+    return this.request('DELETE', this.endpoint + '/' + this.attrs.id, {
       success: json => {
         return this
       },
@@ -136,4 +142,4 @@ var methods = {
   }
 };
 
-module.exports = Model;
+module.exports = model;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yak-orm",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "Yak is an ORM that maps REST resources to JavaScript models/collections",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Now possible to send HTTP headers via all static and instance methods
- Added option to add query params in GET requests via `where` option
- Added installation instructions to README
- Double quote cleanup
- Bumped version to 0.4
