### PR TITLE
Added parse and name arguments for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,42 @@ Inspired by [Backbone.js](http://backbonejs.org/) and [Her](http://www.her-rb.or
 
 ## Installation & Requirements
 
-Yak requires Node.js >= 4.0. To run in a web browser environment you'll need native or polyfilled support for
-ES6 Promises, Object.assign, Fat Arrow Syntax, and the window.fetch API.
+Run `npm install yak-orm` and then simply require it in your project.
 
-Run `npm install yak-orm` and then require it in your project:
+Yak requires Node.js >= 4.0 to run on the server.
+
+To run in a web browser environment you'll need native or polyfilled support for
+ES6 Promises, Object.assign, Fat Arrow Syntax, and the window.fetch API. It's also
+recommended that you use Webpack or Browserify to make your build.
+
+
+## Elevator pitch
 
 ```js
 var Yak = require('yak-orm');
 var yak = new Yak({
   host: "http://localhost:8080/"
 });
+
+var Fruit = yak.model({
+  name: "fruits"
+});
+
+// GET http://localhost:8000/fruits?color=red
+// returns { fruits: [{ name: "apple", name: "pomegranate"}] }
+Fruit.all({
+  where: {
+    color: 'red'
+  }
+}).then(fruits => {
+  fruits.forEach(fruit => {
+    console.log(fruit.attrs.name);
+  });
+});
 ```
 
-You should now be ready to go!
 
-
-## Yak is a work in progress
+### Yak is a work in progress
 
 Features that are on the roadmap but *not yet* currently implemented include:
 
@@ -52,6 +72,7 @@ Create a new Yak instance
 var yak = new Yak({
   host: "http://localhost:8080/"
 });
+
 ```
 
 ### yakInstance.model
@@ -59,13 +80,19 @@ var yak = new Yak({
 Create a new model based on a Yak instance
 
 #### Arguments
-- url (String) | The URL of specified model on API server
+- name (String) | The name of the resource specified on API server
+- url (String, optional) | Resource URI is generated based on name but can be overridden by passing this argument
+- parse (Function(attrs (Object) ), optional) | This method will be called every time a new instance of the model is created. It will receive the model attributes as an argument, allowing you to mutate them before model is created.
 
 #### Example
 ```js
 // Model defintion
 var User = yak.model({
-  url: "users"
+  name: "users",
+  parse: function(attrs) {
+    attrs.fullName = attrs.firstName + " " + attrs.lastName;
+    return attrs;
+  }
 });
 ```
 

--- a/examples/mock-server.js
+++ b/examples/mock-server.js
@@ -8,13 +8,27 @@ server.use(restify.queryParser());
 server.use(restify.bodyParser());
 
 server.pre(function (req, res, next) {
-  console.log("\n-- ", req.method, "---", req.url);
+  console.log("\n-- ", req.method, "--", req.url);
   console.log(req.headers);
   next();
 });
 
 var id = 2;
-var users = [{ id: 1, name: "John Doe", email: "john@doe.com" }]
+var users = [{
+  id: 1,
+  name: "John Doe",
+  email: "john@doe.com",
+  comments: [
+    {
+      postedAt: "1945-12-20",
+      body: "hey ho let's go"
+    },
+    {
+      postedAt: "1946-04-17",
+      body: "you're out of your mind"
+    }
+  ]
+}]
 
 function getUser(id) {
   return users.find(function(user) {
@@ -39,7 +53,9 @@ server.post('/users', function (req, res, next) {
 
 // Get users
 server.get('/users', (req, res, next) => {
-  res.send(users);
+  res.send({
+    users: users
+  });
   return next();
 });
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -5,15 +5,18 @@ var request = require('./request');
 function model(options) {
   var self = this;
   var host = this.host;
-  var endpoint = host + options.url;
+  var endpoint = host + (options.url || options.name);
+  var name = options.name;
   this.errorHandler = function(reject, error, status) {
     return reject(error);
   }
   var fn = function(obj) {
+    obj = obj || {}
+    var attrs = options.parse ? options.parse(obj.attrs) : obj.attrs;
     this.errorHandler = self.errorHandler;
     _.extend(this, {
       host: host,
-      attrs: _.cloneDeep(obj.attrs) || {},
+      attrs: _.cloneDeep(attrs) || {},
       headers: obj.headers || {},
       endpoint: endpoint,
       request: request,
@@ -29,9 +32,11 @@ function model(options) {
    * Returns an Array of models of specified resource
    */
   fn.all = function(obj) {
+    obj = obj || {}
     var qs = 'where' in obj ? '?' + toQueryString(obj.where) : '';
     return request('GET', endpoint + qs, {
       success: function(json) {
+        json = name ? json[name] : json;
         return json.map(attrs => {
           return new fn({ attrs: attrs });
         });

--- a/test/model_test.js
+++ b/test/model_test.js
@@ -8,13 +8,20 @@ var context = new function() {
 }
 var fun = function() { return "funfunfun"}
 var TestModel = context.model({
-  url: "tests",
-  fun: fun
+  name: "fruits",
+  fun: fun,
+  parse: function(attrs) {
+    attrs.test = "test";
+    return attrs
+  }
+});
+
+var TestModel2 = context.model({
+  url: "bears"
 });
 
 
 describe('Model instance', function() {
-
   it('should inherit methods', function() {
     this.model = new TestModel({
       attrs: { foo: 'bar' },
@@ -22,6 +29,11 @@ describe('Model instance', function() {
     });
     assert.equal(this.model.fun, fun);
     assert.equal(this.model.fun(), "funfunfun");
+  });
+  it('should allow empty attrs', function() {
+    var model = new TestModel2();
+    console.log(model);
+    assert.deepEqual(model.attrs, {});
   });
   describe('save new', function() {
     before(function() {
@@ -36,7 +48,7 @@ describe('Model instance', function() {
     });
     describe('success', function() {
       before(function() {
-        this.requestSpy.withArgs('POST', 'http://localhost/tests').returns(
+        this.requestSpy.withArgs('POST', 'http://localhost/fruits').returns(
           new Promise(function(resolve, reject) {
             resolve();
           })
@@ -50,7 +62,7 @@ describe('Model instance', function() {
         assert.equal(this.requestSpy.args[0][0], 'POST')
       });
       it('should call the correct endpoint', function() {
-        assert.equal(this.requestSpy.args[0][1], 'http://localhost/tests');
+        assert.equal(this.requestSpy.args[0][1], 'http://localhost/fruits');
       });
       it('should call with correct headers', function() {
         assert.deepEqual(this.requestSpy.args[0][3], { hello: 'friend' });
@@ -65,7 +77,7 @@ describe('Model instance', function() {
     });
     describe('fail', function() {
       before(function() {
-        this.requestSpy.withArgs('POST', 'http://localhost/tests').returns(
+        this.requestSpy.withArgs('POST', 'http://localhost/fruits').returns(
           new Promise(function(resolve, reject) {
             reject("hello");
           })
@@ -80,6 +92,13 @@ describe('Model instance', function() {
       });
       it('should reject', function () {
         assert(this.naySpy.calledOnce);
+      });
+    });
+    describe('error handler', function() {
+      it('should reject', function() {
+        var rejectSpy = sinon.spy();
+        this.model.errorHandler(rejectSpy, 'lol');
+        assert(rejectSpy.calledWith('lol'));
       });
     });
   });
@@ -97,7 +116,7 @@ describe('Model instance', function() {
     });
     describe('success', function() {
       before(function() {
-        this.requestSpy.withArgs('PATCH', 'http://localhost/tests/5').returns(
+        this.requestSpy.withArgs('PATCH', 'http://localhost/fruits/5').returns(
           new Promise(function(resolve, reject) {
             resolve();
           })
@@ -118,7 +137,7 @@ describe('Model instance', function() {
         assert.deepEqual(this.requestSpy.args[0][3], { hello: 'friend' });
       });
       it('should call the correct endpoint', function() {
-        assert.equal(this.requestSpy.args[0][1], 'http://localhost/tests/5');
+        assert.equal(this.requestSpy.args[0][1], 'http://localhost/fruits/5');
       });
       it('should call success callback', function () {
         assert(this.yaySpy.calledOnce);
@@ -126,7 +145,7 @@ describe('Model instance', function() {
     });
     describe('fail', function() {
       before(function() {
-        this.requestSpy.withArgs('PATCH', 'http://localhost/tests/5').returns(
+        this.requestSpy.withArgs('PATCH', 'http://localhost/fruits/5').returns(
           new Promise(function(resolve, reject) {
             reject('boo');
           })
@@ -158,7 +177,7 @@ describe('Model instance', function() {
 
     describe('success', function() {
       before(function() {
-        this.requestSpy.withArgs('DELETE', 'http://localhost/tests/5').returns(
+        this.requestSpy.withArgs('DELETE', 'http://localhost/fruits/5').returns(
           new Promise(function(resolve, reject) {
             resolve();
           })
@@ -176,7 +195,7 @@ describe('Model instance', function() {
         assert.equal(this.existing, model);
       });
       it('should call the correct endpoint', function() {
-        assert.equal(this.requestSpy.args[0][1], 'http://localhost/tests/5');
+        assert.equal(this.requestSpy.args[0][1], 'http://localhost/fruits/5');
       });
       it('should call success callback', function () {
         assert(this.yaySpy.calledOnce);
@@ -185,7 +204,7 @@ describe('Model instance', function() {
 
     describe('fail', function() {
       before(function() {
-        this.requestSpy.withArgs('DELETE', 'http://localhost/tests/5').returns(
+        this.requestSpy.withArgs('DELETE', 'http://localhost/fruits/5').returns(
           new Promise(function(resolve, reject) {
             reject('foo');
           })
@@ -210,12 +229,12 @@ describe('Model', function() {
   describe('get', function () {
     before(function() {
       var requestSpy = this.requestSpy = sinon.stub();
-      requestSpy.withArgs('GET', 'http://localhost/tests/5?foo=bar&bar=foo').returns(
+      requestSpy.withArgs('GET', 'http://localhost/fruits/5?foo=bar&bar=foo').returns(
         new Promise(function(resolve, reject) {
           resolve({ id: 5 });
         })
       );
-      requestSpy.withArgs('GET', 'http://localhost/tests/10').returns(
+      requestSpy.withArgs('GET', 'http://localhost/fruits/10').returns(
         new Promise(function(resolve, reject) {
           reject('bar');
         })
@@ -241,11 +260,11 @@ describe('Model', function() {
         assert.equal(this.requestSpy.args[0][0], 'GET')
       });
       it('should call the correct endpoint', function() {
-        assert.equal(this.requestSpy.args[0][1], 'http://localhost/tests/5?foo=bar&bar=foo');
+        assert.equal(this.requestSpy.args[0][1], 'http://localhost/fruits/5?foo=bar&bar=foo');
       });
       it('should return new instance of model', function() {
         var model = this.requestSpy.args[0][2].success({ id: 5 });
-        assert.deepEqual(model.attrs, { id: 5 });
+        assert.deepEqual(model.attrs, { id: 5, test: 'test' });
       });
       it('should call success callback', function () {
         assert(this.yaySpy.calledOnce);
@@ -270,12 +289,17 @@ describe('Model', function() {
   describe('all', function () {
     before(function() {
       var requestSpy = this.requestSpy = sinon.stub();
-      requestSpy.withArgs('GET', 'http://localhost/tests?foo=bar&bar=foo').returns(
+      requestSpy.withArgs('GET', 'http://localhost/fruits?foo=bar&bar=foo').returns(
         new Promise(function(resolve, reject) {
           resolve();
         })
       );
-      requestSpy.withArgs('GET', 'http://localhost/tests?fail=me').returns(
+      requestSpy.withArgs('GET', 'http://localhost/bears').returns(
+        new Promise(function(resolve, reject) {
+          resolve();
+        })
+      );
+      requestSpy.withArgs('GET', 'http://localhost/fruits?fail=me').returns(
         new Promise(function(resolve, reject) {
           reject('ha');
         })
@@ -300,14 +324,29 @@ describe('Model', function() {
         assert.equal(this.requestSpy.args[0][0], 'GET')
       });
       it('should return a collection of models', function () {
-        var collection = this.requestSpy.args[0][2].success([{ id: 5 }]);
-        assert.deepEqual(collection[0].attrs, { id: 5 });
+        var collection = this.requestSpy.args[0][2].success({ fruits: [{ id: 5 }]});
+        assert.deepEqual(collection[0].attrs, { id: 5, test: "test" });
       });
       it('should call the correct endpoint', function() {
-        assert.equal(this.requestSpy.args[0][1], 'http://localhost/tests?foo=bar&bar=foo');
+        assert.equal(this.requestSpy.args[0][1], 'http://localhost/fruits?foo=bar&bar=foo');
       });
       it('should call success callback on success', function () {
         assert(this.yaySpy.calledOnce);
+      });
+      describe('without args and model without a name', function() {
+        before(function() {
+          this.yaySpy2 = sinon.spy();
+          TestModel2.all().then(bears => {
+            this.yaySpy2(bears);
+          });
+        });
+        it('should call success callback on success', function () {
+          assert(this.yaySpy2.calledOnce);
+        });
+        it('should return a collection of models', function () {
+          var collection = this.requestSpy.args[1][2].success([{ id: 5 }]);
+          assert.deepEqual(collection[0].attrs, { id: 5 });
+        });
       });
     });
     describe('fail', function() {


### PR DESCRIPTION
The parse argument is a function that will alow you to mutate
any incoming attributes before a new instanceo
of given model is created

the name arguments will allow you to work with named
collections returned from the API. i.e { fruits: [{ name: "apple"}] }
instead of root level collections. i.e [{name: "apple"}]
