### PR TITLE
Added collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Fruit.all({
   where: {
     color: 'red'
   }
-}).then(fruits => {
-  fruits.forEach(fruit => {
+}).then(collection => {
+  collection.fruits.forEach(fruit => {
     console.log(fruit.attrs.name);
   });
 });
@@ -157,8 +157,8 @@ Retrieve a collection of models from server
 #### Example
 ```js
 // GET http://localhost:8080/users
-User.all().then(users => {
-  users.forEach(user => {
+User.all().then(collection => {
+  collection.users.forEach(user => {
     console.log(user.attrs.id, user.attrs.name);
   });
 });

--- a/examples/basic-usage.js
+++ b/examples/basic-usage.js
@@ -43,14 +43,17 @@ var user = User.get({
     'Accept-Language' : 'fa',
   }
 }).then(user => {
+  console.log("\n");
+  console.log("--- \x1b[36m Get user example \x1b[0m ---");
   console.log("Retrieved user:", user.attrs.name);
-  console.log("-- comments --");
+  console.log("Comments:");
   user.attrs.comments.map(function(comment) {
     console.log(comment.attrs.body, "| posted", comment.attrs.yearsAgo, "years ago")
   });
 }).catch(error => {
   console.log(error);
 });
+
 
 // Create a new user
 var user = new User({
@@ -62,14 +65,19 @@ var user = new User({
     'Authentication-Token': 'abc123'
   }
 });
-
 // Persist to server
 user.save().then(user => {
+  console.log("\n");
+  console.log("--- \x1b[36m Create user example \x1b[0m ---");
+  console.log("User id:", user.attrs.id, "created");
+
   // Update user name
   user.attrs.name = "Yak Yak"
-  console.log("User id:", user.attrs.id, "created");
   return user.save()
+
 }).then(user => {
+  console.log("\n");
+  console.log("--- \x1b[36m Update user example \x1b[0m ---");
   console.log("User id:", user.attrs.id, "updated");
 }).catch(error => {
   console.log(error);
@@ -82,10 +90,12 @@ var invalidUser = new User({
     email: "invalid@webcloud.se"
   }
 });
-
 invalidUser.save().then(user => {
   console.log("this should not log");
 }).catch(error => {
+  console.log("\n");
+  console.log("--- \x1b[36m Create invalid user example  \x1b[0m ---");
+  console.log("User id:", user.attrs.id, "created");
   console.log("Could not save user:", error);
 });
 
@@ -95,14 +105,17 @@ User.all({
   where: {
     active : true
   }
-}).then(users => {
-  console.log("Fetching all users:");
-  users.forEach(user => {
-    console.log("\t", user.attrs.id, user.attrs.name);
+}).then(collection => {
+  console.log("\n");
+  console.log("--- \x1b[36m Fetching all users example  \x1b[0m ---");
+  collection.users.forEach(user => {
+    console.log(user.attrs.id, user.attrs.name);
   });
   // Delete the first user
-  return users[1].destroy();
+  return collection.users[1].destroy();
 }).then(user => {
+  console.log("\n");
+  console.log("--- \x1b[36m Delete user example  \x1b[0m ---");
   console.log("User id:", user.attrs.id, "deleted");
 }).catch(error => {
   console.log(error);

--- a/lib/model.js
+++ b/lib/model.js
@@ -36,10 +36,10 @@ function model(options) {
     var qs = 'where' in obj ? '?' + toQueryString(obj.where) : '';
     return request('GET', endpoint + qs, {
       success: function(json) {
-        json = name ? json[name] : json;
-        return json.map(attrs => {
+        json[name] = json[name].map(attrs => {
           return new fn({ attrs: attrs });
         });
+        return json;
       },
       error: self.errorHandler
     }, obj.headers);

--- a/test/model_test.js
+++ b/test/model_test.js
@@ -17,6 +17,7 @@ var TestModel = context.model({
 });
 
 var TestModel2 = context.model({
+  name: "items",
   url: "bears"
 });
 
@@ -32,7 +33,6 @@ describe('Model instance', function() {
   });
   it('should allow empty attrs', function() {
     var model = new TestModel2();
-    console.log(model);
     assert.deepEqual(model.attrs, {});
   });
   describe('save new', function() {
@@ -325,7 +325,7 @@ describe('Model', function() {
       });
       it('should return a collection of models', function () {
         var collection = this.requestSpy.args[0][2].success({ fruits: [{ id: 5 }]});
-        assert.deepEqual(collection[0].attrs, { id: 5, test: "test" });
+        assert.deepEqual(collection.fruits[0].attrs, { id: 5, test: "test" });
       });
       it('should call the correct endpoint', function() {
         assert.equal(this.requestSpy.args[0][1], 'http://localhost/fruits?foo=bar&bar=foo');
@@ -344,8 +344,8 @@ describe('Model', function() {
           assert(this.yaySpy2.calledOnce);
         });
         it('should return a collection of models', function () {
-          var collection = this.requestSpy.args[1][2].success([{ id: 5 }]);
-          assert.deepEqual(collection[0].attrs, { id: 5 });
+          var collection = this.requestSpy.args[1][2].success({ items: [{ id: 5 }]});
+          assert.deepEqual(collection.items[0].attrs, { id: 5 });
         });
       });
     });


### PR DESCRIPTION
This is a backwards incompatible change when using Model.all.
In the callback argument, models are now namespaced under the models
given name. For instance:
```js
var Fruit = yak.model({
  name: "fruits"
});
Fruit.all().then(collection => {
  collection.fruits.forEach(fruit => {
    console.log(fruit.attrs.name);
  });
});
```

This will break any existing implementations relying on the models
being directly accessible via an array in the callback argument